### PR TITLE
fixed typo in color_to_string

### DIFF
--- a/ev3/lego.py
+++ b/ev3/lego.py
@@ -30,7 +30,7 @@ class EV3ColorSensor(sensor.UartSensor):
         self.set_mode(5)
     
     def color_to_string(self):
-        return ["NONE","BALCK","BLUE","GREEN","YELLOW","RED","WHITE","BROWN"][self.get_value()]
+        return ["NONE","BLACK","BLUE","GREEN","YELLOW","RED","WHITE","BROWN"][self.get_value()]
 
 class EV3IRSensor(sensor.UartSensor):
     BUTTON_TOP_LEFT = 1


### PR DESCRIPTION
Fixed typo in color_to_string in the EV3ColorSensor class.
