### PR TITLE
Fixed motor compatibility with current version of ev3dev

### DIFF
--- a/ev3/ev3dev.py
+++ b/ev3/ev3dev.py
@@ -296,7 +296,7 @@ class Motor(Ev3Dev):
         motor_existing = False
         if (port != ''):
             self.port = port
-            for p in glob.glob('/sys/class/tacho-motor/tacho-motor*/port_name'):
+            for p in glob.glob('/sys/class/tacho-motor/motor*/port_name'):
                 with open(p) as f:
                     value = f.read().strip()
                     if (value.lower() == ('out' + port).lower()):
@@ -304,7 +304,7 @@ class Motor(Ev3Dev):
                         motor_existing = True
                         break
         if (_type != '' and port == ''):
-            for p in glob.glob('/sys/class/tacho-motor/tacho-motor*/type'):
+            for p in glob.glob('/sys/class/tacho-motor/motor*/type'):
                 with open(p) as f:
                     value = f.read().strip()
                     if (value.lower() == _type.lower()):


### PR DESCRIPTION
The path for the motors seem to have changed on the last release of ev3dev.

Using fully upgraded ev3dev and python27.

_Jagah Systems AB_
